### PR TITLE
Support optional transform contributors in UniversalGenerator

### DIFF
--- a/lib/generate/universal/universalGenerator.ts
+++ b/lib/generate/universal/universalGenerator.ts
@@ -20,7 +20,8 @@ import {
     Project,
 } from "@atomist/automation-client";
 import {
-    chainTransforms, CodeTransform,
+    chainTransforms,
+    CodeTransform,
     CommandListenerInvocation,
     GeneratorRegistration,
     ParametersObject,

--- a/lib/generate/universal/universalGenerator.ts
+++ b/lib/generate/universal/universalGenerator.ts
@@ -20,7 +20,7 @@ import {
     Project,
 } from "@atomist/automation-client";
 import {
-    chainTransforms,
+    chainTransforms, CodeTransform,
     CommandListenerInvocation,
     GeneratorRegistration,
     ParametersObject,
@@ -45,6 +45,7 @@ import {
 
 interface Analyzed {
     analysis: ProjectAnalysis;
+    transformsToApply: Array<CodeTransform<any>>;
 }
 
 /**
@@ -77,11 +78,11 @@ export function universalGenerator(projectAnalyzer: ProjectAnalyzer,
         transform: async (p, pi) => {
             try {
                 logger.debug("In transform: parameters are %j", pi.parameters);
-                const analysis = (pi.parameters as any as Analyzed).analysis;
-                await displayMessages(pi, analysis);
-                const transforms = _.flatten(analysis.seedAnalysis.transformRecipes.map(r => r.recipe.transforms));
+                const analyzed = pi.parameters as any as Analyzed;
+                await displayMessages(pi, analyzed.analysis);
+                const transforms = analyzed.transformsToApply;
                 await pi.addressChannels(`Running ${transforms.length} transform${transforms.length !== 1 ? "s" : ""} against your seed project`);
-                await addProvenanceFile(p, pi, _.flatten(analysis.seedAnalysis.transformRecipes));
+                await addProvenanceFile(p, pi, _.flatten(analyzed.analysis.seedAnalysis.transformRecipes));
                 // tslint:disable-next-line:deprecation
                 const trans = chainTransforms(...transforms, SdmEnablementTransform);
                 return trans(p, pi, pi.parameters);
@@ -98,15 +99,43 @@ export function universalGenerator(projectAnalyzer: ProjectAnalyzer,
  */
 async function enhanceWithSpecificParameters<P>(analysis: ProjectAnalysis,
                                                 ctx: CommandListenerInvocation<any>): Promise<void> {
-    const parameters: ParametersObject<any> = {};
-    for (const recipeRequest of analysis.seedAnalysis.transformRecipes) {
+    const requiredTransformRecipes = analysis.seedAnalysis.transformRecipes.filter(r => !r.optional);
+    const optionalTransformRecipes = analysis.seedAnalysis.transformRecipes.filter(r => r.optional);
+
+    // Work out which optional parameters are required
+    const transformsToTake: ParametersObject<any> = {};
+    for (const recipeRequest of optionalTransformRecipes) {
+        transformsToTake[recipeRequest.originator] = {
+            type: {
+                options: [{
+                    value: "yes",
+                    description: "yes",
+                }, {
+                    value: "no",
+                    description: "no",
+                }],
+                kind: "single",
+            },
+            description: `Add ${recipeRequest.description}?`,
+        };
+    }
+    const optionalTransformsParams: any = optionalTransformRecipes.length > 0 ?
+        await ctx.promptFor<P>(transformsToTake) :
+        [];
+    const relevantTransformRecipes = requiredTransformRecipes.concat(
+        optionalTransformRecipes.filter(o => optionalTransformsParams[o.originator] === "yes"),
+    );
+    (ctx.parameters as Analyzed).transformsToApply = _.flatten(relevantTransformRecipes.map(r => r.recipe.transforms));
+
+    const unsatisfiedParameters: ParametersObject<any> = {};
+    for (const recipeRequest of relevantTransformRecipes) {
         recipeRequest.recipe.parameters
             .filter(p => !ctx.parameters[p.name])
             .forEach(p => {
-                (parameters as any)[p.name] = p;
+                unsatisfiedParameters[p.name] = p;
             });
     }
-    const newParams: any = await ctx.promptFor<P>(parameters);
+    const newParams: any = await ctx.promptFor<P>(unsatisfiedParameters);
     for (const name of Object.getOwnPropertyNames(newParams)) {
         ctx.parameters[name] = newParams[name];
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -478,9 +478,9 @@
       }
     },
     "@atomist/sdm-pack-analysis": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-analysis/-/sdm-pack-analysis-1.0.0.tgz",
-      "integrity": "sha512-hKi1BvU8Wie8ZU/10YLMQB2gHpUABCP3arKd68BSLHOxflsSeNjmf9sBgCHIc79Z7he7p1na0FGr2dCbleusRw==",
+      "version": "1.0.1-master.20190403065626",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-analysis/-/sdm-pack-analysis-1.0.1-master.20190403065626.tgz",
+      "integrity": "sha512-aaDJEOIL27gccPdFu/iuyuDL8QZH1jYpgtsy/SnqCBOsFryUKEduwc/VnnJSgfYV0uykBDERNySbADYkr1RtlQ==",
       "requires": {
         "@atomist/microgrammar": "^1.2.0",
         "@types/git-url-parse": "^9.0.0",
@@ -493,11 +493,6 @@
         "yamljs": "^0.3.0"
       },
       "dependencies": {
-        "@types/package-json": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@types/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha512-n2zpAg7NZ1r8noPMXwur3tB9VHsElZKJZMRSK4KglQQIdxGZE5LHRczTfLHpRUEJoiM9zIqRF6yThtg7mn49uw=="
-        },
         "ts-essentials": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz",
@@ -1628,6 +1623,11 @@
       "requires": {
         "@types/retry": "*"
       }
+    },
+    "@types/package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha512-n2zpAg7NZ1r8noPMXwur3tB9VHsElZKJZMRSK4KglQQIdxGZE5LHRczTfLHpRUEJoiM9zIqRF6yThtg7mn49uw=="
     },
     "@types/passport": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@atomist/microgrammar": "^1.2.0",
     "@atomist/sdm": "^1.3.1",
     "@atomist/sdm-core": "^1.3.1",
-    "@atomist/sdm-pack-analysis": "^1.0.0",
+    "@atomist/sdm-pack-analysis": "^1.0.1-master.20190403065626",
     "@atomist/sdm-pack-analysis-node": "^1.0.0",
     "@atomist/sdm-pack-analysis-spring": "^1.0.1",
     "@atomist/sdm-pack-build": "^1.0.4",


### PR DESCRIPTION
Make UniversalGenerator (which requires dynamic parameters and hence isn't used in the present core flow) properly support optional transform contributors. This allows recommendations. For example, "would you like to add Spring Security" to a Spring Boot project.