### PR TITLE
Parse Docker file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -539,6 +539,16 @@
         "lodash": "^4.17.11",
         "portfinder": "^1.0.20",
         "vscode-languageserver-types": "^3.14.0"
+      },
+      "dependencies": {
+        "dockerfile-ast": {
+          "version": "0.0.13",
+          "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.13.tgz",
+          "integrity": "sha512-34pi8Tdiae8dVvbOOTO1h8aOymWXkrl0w5bvSyFY50IoQnuhA/pTEENaJQP6TWHqKdxJcKQ/6vsHT44lPBZcIw==",
+          "requires": {
+            "vscode-languageserver-types": "^3.5.0"
+          }
+        }
       }
     },
     "@atomist/sdm-pack-fingerprints": {
@@ -4093,9 +4103,9 @@
       "integrity": "sha512-djh3R7KXkEPm80PXK9xbz8bCfEFuU11Tmf5l9IXKdjBPx91/cOqhwOwtOq6s35B8TqrwY6L4xLphmyYmJT0ZXw=="
     },
     "dockerfile-ast": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.13.tgz",
-      "integrity": "sha512-34pi8Tdiae8dVvbOOTO1h8aOymWXkrl0w5bvSyFY50IoQnuhA/pTEENaJQP6TWHqKdxJcKQ/6vsHT44lPBZcIw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.14.tgz",
+      "integrity": "sha512-OnmQsW9Agoi/a5tnpm9qfrO5XI2K8lJFXI+HNwQzJP/iAqaijNV1E3pNIU1tSqLMJDnjpC3E/VfpHHQWDxSlqQ==",
       "requires": {
         "vscode-languageserver-types": "^3.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/git-url-parse": "^9.0.0",
     "@types/request": "^2.48.1",
     "@types/yamljs": "^0.2.30",
+    "dockerfile-ast": "0.0.14",
     "fs-extra": "^7.0.1",
     "git-url-parse": "^11.1.2",
     "lodash": "^4.17.11",


### PR DESCRIPTION
If a Docker file is found, attempt to extract image and exposed ports using Docker file parser. This adds a direct dependency on `dockerfile-ast`, but there was already such a transitive dependency.

Parsing is only performed on a full analysis, and any exceptions are swallowed so not to risk delivery functionality.